### PR TITLE
no vla-member in anonymous bindFrame (clang compatibility)

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -9,27 +9,24 @@ any apply(any ex, any foo, bool cf, int n, cell *p) {
       if (isCell(foo)) {
          int i;
          any x = car(foo);
-         struct {  // bindFrame
-            struct bindFrame *link;
-            int i, cnt;
-            struct {any sym; any val;} bnd[length(x)+2];
-         } f;
+         char fbuf[bindFrameSize(length(x)+2)];
+         bindFrame *f = (bindFrame*)fbuf;
 
-         f.link = Env.bind,  Env.bind = (bindFrame*)&f;
-         f.i = 0;
-         f.cnt = 1,  f.bnd[0].sym = At,  f.bnd[0].val = val(At);
+         f->link = Env.bind,  Env.bind = f;
+         f->i = 0;
+         f->cnt = 1,  f->bnd[0].sym = At,  f->bnd[0].val = val(At);
          while (isCell(x)) {
-            f.bnd[f.cnt].val = val(f.bnd[f.cnt].sym = car(x));
-            val(f.bnd[f.cnt].sym) = --n<0? Nil : cf? car(data(p[f.cnt-1])) : data(p[f.cnt-1]);
-            ++f.cnt, x = cdr(x);
+            f->bnd[f->cnt].val = val(f->bnd[f->cnt].sym = car(x));
+            val(f->bnd[f->cnt].sym) = --n<0? Nil : cf? car(data(p[f->cnt-1])) : data(p[f->cnt-1]);
+            ++f->cnt, x = cdr(x);
          }
          if (isNil(x))
             x = prog(cdr(foo));
          else if (x != At) {
-            f.bnd[f.cnt].sym = x,  f.bnd[f.cnt].val = val(x),  val(x) = Nil;
+            f->bnd[f->cnt].sym = x,  f->bnd[f->cnt].val = val(x),  val(x) = Nil;
             while (--n >= 0)
-               val(x) = cons(consSym(cf? car(data(p[n+f.cnt-1])) : data(p[n+f.cnt-1]), Nil), val(x));
-            ++f.cnt;
+               val(x) = cons(consSym(cf? car(data(p[n+f->cnt-1])) : data(p[n+f->cnt-1]), Nil), val(x));
+            ++f->cnt;
             x = prog(cdr(foo));
          }
          else {
@@ -39,16 +36,16 @@ any apply(any ex, any foo, bool cf, int n, cell *p) {
             cell c[Env.next = n];
 
             Env.arg = c;
-            for (i = f.cnt-1;  --n >= 0;  ++i)
+            for (i = f->cnt-1;  --n >= 0;  ++i)
                Push(c[n], cf? car(data(p[i])) : data(p[i]));
             x = prog(cdr(foo));
             if (cnt)
                drop(c[cnt-1]);
             Env.arg = arg,  Env.next = next;
          }
-         while (--f.cnt >= 0)
-            val(f.bnd[f.cnt].sym) = f.bnd[f.cnt].val;
-         Env.bind = f.link;
+         while (--f->cnt >= 0)
+            val(f->bnd[f->cnt].sym) = f->bnd[f->cnt].val;
+         Env.bind = f->link;
          return x;
       }
       if (val(foo) == val(Meth)) {
@@ -61,35 +58,32 @@ any apply(any ex, any foo, bool cf, int n, cell *p) {
          if (expr = method(o)) {
             int i;
             any cls = Env.cls, key = Env.key;
-            struct {  // bindFrame
-               struct bindFrame *link;
-               int i, cnt;
-               struct {any sym; any val;} bnd[length(x = car(expr))+3];
-            } f;
+            char fbuf[bindFrameSize(length(x = car(expr))+3)];
+            bindFrame *f = (bindFrame*)fbuf;
 
             Env.cls = TheCls,  Env.key = TheKey;
-            f.link = Env.bind,  Env.bind = (bindFrame*)&f;
-            f.i = 0;
-            f.cnt = 1,  f.bnd[0].sym = At,  f.bnd[0].val = val(At);
+            f->link = Env.bind,  Env.bind = f;
+            f->i = 0;
+            f->cnt = 1,  f->bnd[0].sym = At,  f->bnd[0].val = val(At);
             --n, ++p;
             while (isCell(x)) {
-               f.bnd[f.cnt].val = val(f.bnd[f.cnt].sym = car(x));
-               val(f.bnd[f.cnt].sym) = --n<0? Nil : cf? car(data(p[f.cnt-1])) : data(p[f.cnt-1]);
-               ++f.cnt, x = cdr(x);
+               f->bnd[f->cnt].val = val(f->bnd[f->cnt].sym = car(x));
+               val(f->bnd[f->cnt].sym) = --n<0? Nil : cf? car(data(p[f->cnt-1])) : data(p[f->cnt-1]);
+               ++f->cnt, x = cdr(x);
             }
             if (isNil(x)) {
-               f.bnd[f.cnt].sym = This;
-               f.bnd[f.cnt++].val = val(This);
+               f->bnd[f->cnt].sym = This;
+               f->bnd[f->cnt++].val = val(This);
                val(This) = o;
                x = prog(cdr(expr));
             }
             else if (x != At) {
-               f.bnd[f.cnt].sym = x,  f.bnd[f.cnt].val = val(x),  val(x) = Nil;
+               f->bnd[f->cnt].sym = x,  f->bnd[f->cnt].val = val(x),  val(x) = Nil;
                while (--n >= 0)
-                  val(x) = cons(consSym(cf? car(data(p[n+f.cnt-1])) : data(p[n+f.cnt-1]), Nil), val(x));
-               ++f.cnt;
-               f.bnd[f.cnt].sym = This;
-               f.bnd[f.cnt++].val = val(This);
+                  val(x) = cons(consSym(cf? car(data(p[n+f->cnt-1])) : data(p[n+f->cnt-1]), Nil), val(x));
+               ++f->cnt;
+               f->bnd[f->cnt].sym = This;
+               f->bnd[f->cnt++].val = val(This);
                val(This) = o;
                x = prog(cdr(expr));
             }
@@ -100,19 +94,19 @@ any apply(any ex, any foo, bool cf, int n, cell *p) {
                cell c[Env.next = n];
 
                Env.arg = c;
-               for (i = f.cnt-1;  --n >= 0;  ++i)
+               for (i = f->cnt-1;  --n >= 0;  ++i)
                   Push(c[n], cf? car(data(p[i])) : data(p[i]));
-               f.bnd[f.cnt].sym = This;
-               f.bnd[f.cnt++].val = val(This);
+               f->bnd[f->cnt].sym = This;
+               f->bnd[f->cnt++].val = val(This);
                val(This) = o;
                x = prog(cdr(expr));
                if (cnt)
                   drop(c[cnt-1]);
                Env.arg = arg,  Env.next = next;
             }
-            while (--f.cnt >= 0)
-               val(f.bnd[f.cnt].sym) = f.bnd[f.cnt].val;
-            Env.bind = f.link;
+            while (--f->cnt >= 0)
+               val(f->bnd[f->cnt].sym) = f->bnd[f->cnt].val;
+            Env.bind = f->link;
             Env.cls = cls,  Env.key = key;
             return x;
          }

--- a/src/pico.h
+++ b/src/pico.h
@@ -79,6 +79,7 @@ typedef struct bindFrame {
    int i, cnt;
    struct {any sym; any val;} bnd[1];
 } bindFrame;
+#define bindFrameSize(n) (sizeof(bindFrame) + sizeof(any)*2*( (n) - 1 ))
 
 typedef struct inFile {
    int fd, ix, cnt, next;


### PR DESCRIPTION
VLAs as struct members are intentionally unsupported by LLVM and will likely never be implemented [1].
This patch replaces the anonymous struct declaration containing a VLA with a char VLA that is large enough for the bindFrame struct + variable elements.
A macro is defined for the size calculation.
The diff is a tad noisy because all occurrences of the bindFrame instance must now be pointers.

http://releases.llvm.org/6.0.0/tools/clang/docs/UsersManual.html